### PR TITLE
Updated ES client version to 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <sonar.version>3.6.0.1398</sonar.version>
 
         <!--Elastic search properties-->
-        <elasticsearch.version>6.7.2</elasticsearch.version>
+        <elasticsearch.version>7.0.0</elasticsearch.version>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
**Summary**

- Updated ES client transport version to 7.0.0
- Bumped up version to 0.0.2
- Resolved build issue in travis - Reference 
https://travis-ci.community/t/the-travis-ci-build-could-not-be-completed-due-to-an-error/1345/15
