### PR TITLE
Es 7.1 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Use the following maven dependency:
 </dependency>
 ```
 
+### Version support
+| jelastic      |  es transport client|
+| ------------- | ------------------- |
+| 0.0.3         | 7.1.0               |
+
 ### Configuration
 ```yaml
 jelastic:

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ Use the following maven dependency:
 <dependency>
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.2</version>
 </dependency>
 ```
 
 ### Version support
 | jelastic      |  es transport client|
 | ------------- | ------------------- |
-| 0.0.3         | 7.1.0               |
+| 0.0.2         | 7.1.0               |
 
 ### Configuration
 ```yaml

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Use the following maven dependency:
 <dependency>
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 
     <licenses>
         <license>
@@ -57,7 +57,7 @@
         <sonar.version>3.6.0.1398</sonar.version>
 
         <!--Elastic search properties-->
-        <elasticsearch.version>7.0.0</elasticsearch.version>
+        <elasticsearch.version>7.1.0</elasticsearch.version>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.3</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/io/github/jelastic/core/models/mapping/CreateMappingRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/mapping/CreateMappingRequest.java
@@ -15,6 +15,7 @@
  */
 package io.github.jelastic.core.models.mapping;
 
+import io.github.jelastic.core.models.helper.MapElement;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -41,6 +42,6 @@ public class CreateMappingRequest {
     private String mappingType;
 
     @NotNull
-    private Object mappingSource;
+    private MapElement mappingSource;
 
 }

--- a/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
+++ b/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
@@ -47,6 +47,7 @@ import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 
@@ -149,7 +150,7 @@ public class ElasticRepository implements Closeable {
                         entitySaveRequest.getMappingType(),
                         entitySaveRequest.getReferenceId()
                 )
-                .setSource(entitySaveRequest.getValue());
+                .setSource(entitySaveRequest.getValue(), XContentType.JSON);
         indexRequestBuilder.setRefreshPolicy(
                 WriteRequest.RefreshPolicy.IMMEDIATE
         ).execute().get();


### PR DESCRIPTION
1. BumpUp model and transport client version to 7.1.0

2. CreateMappingRequest takes in MappingSource of type MapElement

The CreateMappingRequest was accepting Object as mappingSource,  which should have been MapElement as defined for CreateTemplateRequest, this resulted in the below exception. 
```
INFO  [2019-06-27 14:17:22,802] [dw-45 - POST /v1/discovery/namespace/category] [CategoryResource]: invoke createMapping mapping
ERROR [2019-06-27 14:17:22,805] [dw-45 - POST /v1/discovery/namespace/category] [LoggingExceptionMapper]: Error handling a request: 5bf640b13c83686b
java.lang.IllegalArgumentException: mapping source must be pairs of fieldnames and properties definition.
        at org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest.buildFromSimplifiedDef(PutMappingRequest.java:210)
        at org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest.source(PutMappingRequest.java:185)
        at org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder.setSource(PutMappingRequestBuilder.java:99)
        at io.github.jelastic.core.repository.ElasticRepository.createMapping(ElasticRepository.java:85)
        at com.namespace.discovery.core.category.CategoryService.createMapping(CategoryService.java:68)
        at com.namespace.discovery.core.resources.CategoryResource.createCategory(CategoryResource.java:66)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

```

3. Pass additional field XContentType.JSON when entity is being persisted. 
```
INFO  [2019-06-27 14:24:03,929] [dw-46 - POST /v1/discovery/namespace/category] [CategoryResource]: invoke category insert
ERROR [2019-06-27 14:24:03,940] [dw-46 - POST /v1/discovery/namespace/category] [LoggingExceptionMapper]: Error handling a request: ccd693d8c28b43d4
java.lang.IllegalArgumentException: The number of object passed must be even but was [1]
        at org.elasticsearch.action.index.IndexRequest.source(IndexRequest.java:384)
        at org.elasticsearch.action.index.IndexRequest.source(IndexRequest.java:371)
        at org.elasticsearch.action.index.IndexRequestBuilder.setSource(IndexRequestBuilder.java:152)
        at io.github.jelastic.core.repository.ElasticRepository.save(ElasticRepository.java:153)
```
Link - https://stackoverflow.com/a/51721034

The above changes were done to resolve exception that were encountered during integration with ES 7.1.0.