### PR TITLE
multi field update support + Added validations to fail fast

### DIFF
--- a/src/main/java/io/github/jelastic/core/exception/InvalidRequestException.java
+++ b/src/main/java/io/github/jelastic/core/exception/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package io.github.jelastic.core.exception;
+
+public class InvalidRequestException extends RuntimeException {
+  public InvalidRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/github/jelastic/core/models/mapping/CreateMappingRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/mapping/CreateMappingRequest.java
@@ -20,7 +20,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
 
@@ -34,11 +33,9 @@ import javax.validation.constraints.NotNull;
 public class CreateMappingRequest {
 
     @NotNull
-    @NotEmpty
     private String indexName;
 
     @NotNull
-    @NotEmpty
     private String mappingType;
 
     @NotNull

--- a/src/main/java/io/github/jelastic/core/models/search/IdSearchRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/search/IdSearchRequest.java
@@ -15,10 +15,10 @@
  */
 package io.github.jelastic.core.models.search;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.List;
-
 /**
  * @author koushik
  */
@@ -28,8 +28,10 @@ import java.util.List;
 @Setter
 @Builder
 public class IdSearchRequest<T> {
+    @NotNull
     private String index;
     private String type;
+    @NotNull
     private List<String> ids;
     private Class<T> klass;
 }

--- a/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
@@ -16,6 +16,7 @@
 package io.github.jelastic.core.models.search;
 
 import io.github.jelastic.core.models.query.Query;
+import javax.validation.constraints.NotNull;
 import lombok.*;
 
 /**
@@ -27,8 +28,11 @@ import lombok.*;
 @Setter
 @Builder
 public class SearchRequest<T> {
+    @NotNull
     private String index;
+    @NotNull
     private String type;
+    @NotNull
     private Query query;
     private Class<T> klass;
 }

--- a/src/main/java/io/github/jelastic/core/models/source/EntitySaveRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/EntitySaveRequest.java
@@ -15,6 +15,7 @@
  */
 package io.github.jelastic.core.models.source;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
 
 /**
@@ -26,9 +27,12 @@ import lombok.*;
 @Setter
 @Builder
 public class EntitySaveRequest {
+
+    @NotNull
     private String indexName;
     private String mappingType;
     private String referenceId;
+    @NotNull
     private String value;
 
 }

--- a/src/main/java/io/github/jelastic/core/models/source/GetSourceRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/GetSourceRequest.java
@@ -15,6 +15,7 @@
  */
 package io.github.jelastic.core.models.source;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
 
 /**
@@ -26,7 +27,9 @@ import lombok.*;
 @Setter
 @Builder
 public class GetSourceRequest<T> {
+    @NotNull
     private String referenceId;
+    @NotNull
     private String indexName;
     private String mappingType;
     private Class<T> klass;

--- a/src/main/java/io/github/jelastic/core/models/source/UpdateEntityRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/UpdateEntityRequest.java
@@ -15,6 +15,7 @@
  */
 package io.github.jelastic.core.models.source;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
 
 /**
@@ -26,8 +27,13 @@ import lombok.*;
 @Setter
 @Builder
 public class UpdateEntityRequest {
+    @NotNull
     private String indexName;
     private String mappingType;
+
+    @NotNull
     private String referenceId;
+
+    @NotNull
     private String value;
 }

--- a/src/main/java/io/github/jelastic/core/models/source/UpdateFieldRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/UpdateFieldRequest.java
@@ -15,7 +15,13 @@
  */
 package io.github.jelastic.core.models.source;
 
-import lombok.*;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author koushik
@@ -26,10 +32,15 @@ import lombok.*;
 @Setter
 @Builder
 public class UpdateFieldRequest {
+
+    @NotNull
     private String indexName;
     private String mappingType;
+
+    @NotNull
     private String referenceId;
-    private String field;
-    private Object value;
+
+    @NotNull
+    private Map<String, Object> fieldValueMap;
     private int retryCount;
 }

--- a/src/main/java/io/github/jelastic/core/models/template/CreateTemplateRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/template/CreateTemplateRequest.java
@@ -17,6 +17,7 @@ package io.github.jelastic.core.models.template;
 
 import io.github.jelastic.core.models.helper.MapElement;
 import io.github.jelastic.core.models.index.IndexProperties;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class CreateTemplateRequest {
+    @NotNull
     private String templateName;
     private String indexPattern;
     private String mappingType;

--- a/src/main/java/io/github/jelastic/core/utils/ValidationUtil.java
+++ b/src/main/java/io/github/jelastic/core/utils/ValidationUtil.java
@@ -1,0 +1,28 @@
+package io.github.jelastic.core.utils;
+
+import io.github.jelastic.core.exception.InvalidRequestException;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ValidationUtil {
+
+  private ValidationUtil() {
+  }
+
+  public static <T> void validateRequest(T request) {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+    Set<ConstraintViolation<T>> errors = validator.validate(request);
+
+    if (!errors.isEmpty()) {
+      log.error("Error in validating request {} Error : {}", request, errors);
+      throw new InvalidRequestException("Invalid Request");
+    }
+  }
+}
+


### PR DESCRIPTION
-  Added validations to fail on invalid request
    -  If create, update & search Request has missing fields (ex - no index specified or no value).  During command execution es client used to throw error, Instead of relying on that added validation code to fail fast in case necessary parameters are not present.

-  UpdateField to work on Map<String,Value> instead of single field
    -  Most use case of update requires us to update couple of fields rather than single field. Modified code to work on Map instead of working on single field and value.
