### PR TITLE
Polymorphic sorter + Shard routing+ Delete document+ Constant Score & Match Filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>7.2.0-5</version>
+    <version>7.2.0-5-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>7.2.0-5-SNAPSHOT</version>
+    <version>7.2.0-5</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jelastic</groupId>
     <artifactId>jelastic</artifactId>
     <packaging>jar</packaging>
-    <version>7.2.0-3-SNAPSHOT</version>
+    <version>7.2.0-4-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/io/github/jelastic/core/elastic/ElasticQueryBuilder.java
+++ b/src/main/java/io/github/jelastic/core/elastic/ElasticQueryBuilder.java
@@ -133,4 +133,16 @@ public class ElasticQueryBuilder implements FilterVisitor<QueryBuilder> {
         orFilter.getFilters().forEach(k -> boolQueryBuilder.should(k.accept(this)));
         return boolQueryBuilder;
     }
+
+    @Override
+    public QueryBuilder visit(ConstantScoreFilter constantScoreFilter) {
+        BoolQueryBuilder boolQueryBuilder = boolQuery();
+        constantScoreFilter.getFilters().forEach(k -> boolQueryBuilder.must(k.accept(this)));
+        return constantScoreQuery(boolQueryBuilder);
+    }
+
+    @Override
+    public QueryBuilder visit(MatchFilter matchFilter) {
+        return matchQuery(matchFilter.getFieldName(), matchFilter.getValue());
+    }
 }

--- a/src/main/java/io/github/jelastic/core/elastic/ElasticQueryBuilder.java
+++ b/src/main/java/io/github/jelastic/core/elastic/ElasticQueryBuilder.java
@@ -143,6 +143,6 @@ public class ElasticQueryBuilder implements FilterVisitor<QueryBuilder> {
 
     @Override
     public QueryBuilder visit(MatchFilter matchFilter) {
-        return matchQuery(matchFilter.getFieldName(), matchFilter.getValue());
+        return matchQuery(matchFilter.getFieldName(), getNormalizedValue(matchFilter.getValue()));
     }
 }

--- a/src/main/java/io/github/jelastic/core/elastic/ElasticSortBuilder.java
+++ b/src/main/java/io/github/jelastic/core/elastic/ElasticSortBuilder.java
@@ -1,9 +1,6 @@
 package io.github.jelastic.core.elastic;
 
-import io.github.jelastic.core.models.query.sorter.FieldSorter;
-import io.github.jelastic.core.models.query.sorter.GeoDistanceSorter;
-import io.github.jelastic.core.models.query.sorter.ScriptSorter;
-import io.github.jelastic.core.models.query.sorter.SorterVisitor;
+import io.github.jelastic.core.models.query.sorter.*;
 import io.github.jelastic.core.utils.ElasticUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -30,4 +27,8 @@ public class ElasticSortBuilder implements SorterVisitor<SortBuilder> {
                 .order(ElasticUtils.getSortOrder(scriptSorter.getSortOrder()));
     }
 
+    @Override
+    public SortBuilder visit(ScoreSorter scoreSorter) {
+        return SortBuilders.scoreSort().order(ElasticUtils.getSortOrder(scoreSorter.getSortOrder()));
+    }
 }

--- a/src/main/java/io/github/jelastic/core/elastic/ElasticSortBuilder.java
+++ b/src/main/java/io/github/jelastic/core/elastic/ElasticSortBuilder.java
@@ -1,0 +1,33 @@
+package io.github.jelastic.core.elastic;
+
+import io.github.jelastic.core.models.query.sorter.FieldSorter;
+import io.github.jelastic.core.models.query.sorter.GeoDistanceSorter;
+import io.github.jelastic.core.models.query.sorter.ScriptSorter;
+import io.github.jelastic.core.models.query.sorter.SorterVisitor;
+import io.github.jelastic.core.utils.ElasticUtils;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+
+public class ElasticSortBuilder implements SorterVisitor<SortBuilder> {
+
+    @Override
+    public SortBuilder visit(FieldSorter fieldSorter) {
+        return SortBuilders.fieldSort(fieldSorter.getFieldName())
+                .order(ElasticUtils.getSortOrder(fieldSorter.getSortOrder()));
+    }
+
+    @Override
+    public SortBuilder visit(GeoDistanceSorter geoDistanceSorter) {
+        return SortBuilders.geoDistanceSort(geoDistanceSorter.getFieldName(),
+                geoDistanceSorter.getGeoPoints().toArray(new GeoPoint[geoDistanceSorter.getGeoPoints().size()]))
+                .order(ElasticUtils.getSortOrder(geoDistanceSorter.getSortOrder()));
+    }
+
+    @Override
+    public SortBuilder visit(ScriptSorter scriptSorter) {
+        return SortBuilders.scriptSort(scriptSorter.getScript(), scriptSorter.getScriptSortType())
+                .order(ElasticUtils.getSortOrder(scriptSorter.getSortOrder()));
+    }
+
+}

--- a/src/main/java/io/github/jelastic/core/managers/QueryManager.java
+++ b/src/main/java/io/github/jelastic/core/managers/QueryManager.java
@@ -16,14 +16,19 @@
 package io.github.jelastic.core.managers;
 
 import io.github.jelastic.core.elastic.ElasticQueryBuilder;
+import io.github.jelastic.core.elastic.ElasticSortBuilder;
 import io.github.jelastic.core.exception.InvalidQueryException;
 import io.github.jelastic.core.models.query.JElasticQuery;
 import io.github.jelastic.core.models.query.Query;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
 
 import javax.inject.Singleton;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
@@ -36,8 +41,11 @@ public class QueryManager {
 
     private ElasticQueryBuilder elasticQueryBuilder;
 
+    private ElasticSortBuilder elasticSortBuilder;
+
     public QueryManager() {
         this.elasticQueryBuilder = new ElasticQueryBuilder();
+        this.elasticSortBuilder = new ElasticSortBuilder();
     }
 
     @Deprecated
@@ -53,7 +61,7 @@ public class QueryManager {
         return boolQueryBuilder;
     }
 
-    public QueryBuilder getQueryBuilder(JElasticQuery query){
+    public QueryBuilder getQueryBuilder(JElasticQuery query) {
         BoolQueryBuilder boolQueryBuilder = boolQuery();
 
         try {
@@ -62,6 +70,12 @@ public class QueryManager {
             throw new InvalidQueryException("Query incorrect: " + e.getMessage(), e);
         }
         return boolQueryBuilder;
+
+    }
+
+    public List<SortBuilder> getSortBuilders(JElasticQuery query) {
+        return  query.getSorters().stream().map(sorter ->
+                sorter.accept(elasticSortBuilder)).collect(Collectors.toList());
 
     }
 

--- a/src/main/java/io/github/jelastic/core/managers/QueryManager.java
+++ b/src/main/java/io/github/jelastic/core/managers/QueryManager.java
@@ -40,6 +40,7 @@ public class QueryManager {
         this.elasticQueryBuilder = new ElasticQueryBuilder();
     }
 
+    @Deprecated
     public QueryBuilder getQueryBuilder(Query query) {
         BoolQueryBuilder boolQueryBuilder = boolQuery();
 

--- a/src/main/java/io/github/jelastic/core/managers/QueryManager.java
+++ b/src/main/java/io/github/jelastic/core/managers/QueryManager.java
@@ -17,6 +17,7 @@ package io.github.jelastic.core.managers;
 
 import io.github.jelastic.core.elastic.ElasticQueryBuilder;
 import io.github.jelastic.core.exception.InvalidQueryException;
+import io.github.jelastic.core.models.query.JElasticQuery;
 import io.github.jelastic.core.models.query.Query;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -49,6 +50,18 @@ public class QueryManager {
         }
 
         return boolQueryBuilder;
+    }
+
+    public QueryBuilder getQueryBuilder(JElasticQuery query){
+        BoolQueryBuilder boolQueryBuilder = boolQuery();
+
+        try {
+            query.getFilters().forEach(k -> boolQueryBuilder.must(k.accept(elasticQueryBuilder)));
+        } catch (Exception e) {
+            throw new InvalidQueryException("Query incorrect: " + e.getMessage(), e);
+        }
+        return boolQueryBuilder;
+
     }
 
 

--- a/src/main/java/io/github/jelastic/core/models/index/IndexProperties.java
+++ b/src/main/java/io/github/jelastic/core/models/index/IndexProperties.java
@@ -34,4 +34,6 @@ public class IndexProperties {
     private int noOfReplicas;
 
     private boolean enableRequestCache;
+
+    private Integer noOfRoutingShards;
 }

--- a/src/main/java/io/github/jelastic/core/models/query/JElasticQuery.java
+++ b/src/main/java/io/github/jelastic/core/models/query/JElasticQuery.java
@@ -1,0 +1,53 @@
+package io.github.jelastic.core.models.query;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Sets;
+import io.github.jelastic.core.models.query.filter.Filter;
+import io.github.jelastic.core.models.query.paged.PageWindow;
+import io.github.jelastic.core.models.query.sorter.JElasticSorter;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JElasticQuery {
+
+    public static String RAW_QUERY_NAME = "rawQuery";
+    @NonNull
+    public PageWindow pageWindow;
+    @Builder.Default
+    private String queryName = "query";
+    @JsonProperty
+    @NonNull
+    @Builder.Default
+    private Set<Filter> filters = new HashSet();
+    @JsonProperty
+    @NonNull
+    @Builder.Default
+    private Set<JElasticSorter> sorters = new TreeSet();
+
+
+
+    public void addFilter(Filter filter) {
+        if (Objects.isNull(filters) || filters.isEmpty()) {
+            this.filters = Sets.newHashSet(filter);
+        } else {
+            this.filters.add(filter);
+        }
+    }
+
+    public void addJElasticSorter(JElasticSorter sorter) {
+        if (Objects.isNull(sorters) || sorters.isEmpty()) {
+            this.sorters = Sets.newTreeSet();
+        }
+
+        this.sorters.add(sorter);
+    }
+}

--- a/src/main/java/io/github/jelastic/core/models/query/Query.java
+++ b/src/main/java/io/github/jelastic/core/models/query/Query.java
@@ -29,6 +29,7 @@ import java.util.TreeSet;
 
 /**
  * Created by koushikr
+ * @deprecated as of 7.2.0-4, replaced by {@link JElasticQuery}
  */
 @Getter
 @Setter

--- a/src/main/java/io/github/jelastic/core/models/query/Query.java
+++ b/src/main/java/io/github/jelastic/core/models/query/Query.java
@@ -35,6 +35,7 @@ import java.util.TreeSet;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Deprecated
 public class Query {
 
     public static String RAW_QUERY_NAME = "rawQuery";

--- a/src/main/java/io/github/jelastic/core/models/query/filter/Filter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/Filter.java
@@ -44,7 +44,8 @@ import lombok.SneakyThrows;
         @JsonSubTypes.Type(value = MissingFilter.class, name = FilterType.MISSING),
         @JsonSubTypes.Type(value = ContainsFilter.class, name = FilterType.CONTAINS),
         @JsonSubTypes.Type(value = AndFilter.class, name = FilterType.AND),
-        @JsonSubTypes.Type(value = ORFilter.class, name = FilterType.OR)
+        @JsonSubTypes.Type(value = ORFilter.class, name = FilterType.OR),
+        @JsonSubTypes.Type(value = ConstantScoreFilter.class, name = FilterType.CONSTANT_SCORE)
 })
 @Data
 public abstract class Filter {

--- a/src/main/java/io/github/jelastic/core/models/query/filter/Filter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/Filter.java
@@ -45,7 +45,8 @@ import lombok.SneakyThrows;
         @JsonSubTypes.Type(value = ContainsFilter.class, name = FilterType.CONTAINS),
         @JsonSubTypes.Type(value = AndFilter.class, name = FilterType.AND),
         @JsonSubTypes.Type(value = ORFilter.class, name = FilterType.OR),
-        @JsonSubTypes.Type(value = ConstantScoreFilter.class, name = FilterType.CONSTANT_SCORE)
+        @JsonSubTypes.Type(value = ConstantScoreFilter.class, name = FilterType.CONSTANT_SCORE),
+        @JsonSubTypes.Type(value = MatchFilter.class, name = FilterType.MATCH)
 })
 @Data
 public abstract class Filter {

--- a/src/main/java/io/github/jelastic/core/models/query/filter/FilterType.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/FilterType.java
@@ -36,6 +36,8 @@ public interface FilterType {
     String EXISTS = "EXISTS";
     String MISSING = "MISSING";
     String CONTAINS = "CONTAINS";
+    String CONSTANT_SCORE = "CONSTANT_SCORE";
+    String MATCH = "MATCH";
 
     /* Predicates */
     String AND = "AND";

--- a/src/main/java/io/github/jelastic/core/models/query/filter/FilterVisitor.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/FilterVisitor.java
@@ -57,4 +57,8 @@ public interface FilterVisitor<T> {
 
     T visit(ORFilter orFilter);
 
+    T visit(ConstantScoreFilter constantScoreFilter);
+
+    T visit(MatchFilter matchFilter);
+
 }

--- a/src/main/java/io/github/jelastic/core/models/query/filter/general/ConstantScoreFilter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/general/ConstantScoreFilter.java
@@ -1,0 +1,38 @@
+package io.github.jelastic.core.models.query.filter.general;
+
+import io.github.jelastic.core.models.query.filter.Filter;
+import io.github.jelastic.core.models.query.filter.FilterType;
+import io.github.jelastic.core.models.query.filter.FilterVisitor;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ConstantScoreFilter extends Filter {
+
+    @Singular
+    private List<Filter> filters;
+
+    protected ConstantScoreFilter() {
+      super(FilterType.CONSTANT_SCORE);
+    }
+
+    @Builder
+    public ConstantScoreFilter(@Singular List<Filter> filters) {
+        super(FilterType.CONSTANT_SCORE);
+        this.filters = filters;
+    }
+
+    @Override
+    public boolean validate() {
+      return filters.stream().map(Filter::validate).reduce((x, y) -> x && y).orElse(false);
+    }
+
+    @Override
+    public <V> V accept(FilterVisitor<V> visitor) {
+    return visitor.visit(this);
+  }
+}
+

--- a/src/main/java/io/github/jelastic/core/models/query/filter/general/MatchFilter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/filter/general/MatchFilter.java
@@ -1,0 +1,29 @@
+package io.github.jelastic.core.models.query.filter.general;
+
+import io.github.jelastic.core.models.query.filter.Filter;
+import io.github.jelastic.core.models.query.filter.FilterType;
+import io.github.jelastic.core.models.query.filter.FilterVisitor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class MatchFilter extends Filter {
+
+    private Object value;
+
+    public MatchFilter() { super(FilterType.MATCH); }
+
+    public MatchFilter(String field, Object value) {
+        super(FilterType.MATCH, field);
+        this.value = value;
+    }
+
+    @Override
+    public <V> V accept(FilterVisitor<V> visitor) {
+      return visitor.visit(this);
+    }
+
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/FieldSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/FieldSorter.java
@@ -1,0 +1,32 @@
+package io.github.jelastic.core.models.query.sorter;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class FieldSorter extends JElasticSorter {
+
+    @NotNull
+    @NotEmpty
+    private String fieldName;
+
+    public FieldSorter(){super(SorterType.FIELD);}
+
+    @Builder
+    public FieldSorter(int priority, SortOrder sortOrder, String fieldName) {
+        super(priority, sortOrder, SorterType.FIELD);
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public <V> V accept(SorterVisitor<V> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/GeoDistanceSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/GeoDistanceSorter.java
@@ -1,0 +1,39 @@
+package io.github.jelastic.core.models.query.sorter;
+
+
+import lombok.*;
+import org.elasticsearch.common.geo.GeoPoint;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class GeoDistanceSorter extends JElasticSorter {
+
+    @NotNull
+    @NotEmpty
+    private String fieldName;
+
+    @NotNull
+    @NotEmpty
+    @Singular
+    private Set<GeoPoint> geoPoints;
+
+    public GeoDistanceSorter(){super(SorterType.GEO_DISTANCE);}
+
+    @Builder
+    public GeoDistanceSorter(int priority, SortOrder sortOrder, String fieldName, @Singular Set<GeoPoint> geoPoints){
+        super(priority, sortOrder, SorterType.GEO_DISTANCE);
+        this.geoPoints = geoPoints;
+
+    }
+
+    @Override
+    public <V> V accept(SorterVisitor<V> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/GeoDistanceSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/GeoDistanceSorter.java
@@ -28,6 +28,7 @@ public class GeoDistanceSorter extends JElasticSorter {
     public GeoDistanceSorter(int priority, SortOrder sortOrder, String fieldName, @Singular Set<GeoPoint> geoPoints){
         super(priority, sortOrder, SorterType.GEO_DISTANCE);
         this.geoPoints = geoPoints;
+        this.fieldName = fieldName;
 
     }
 

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
@@ -1,0 +1,47 @@
+package io.github.jelastic.core.models.query.sorter;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.ComparisonChain;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sorterType")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = FieldSorter.class, name = SorterType.FIELD),
+        @JsonSubTypes.Type(value = GeoDistanceSorter.class, name = SorterType.GEO_DISTANCE),
+        @JsonSubTypes.Type(value = ScriptSorter.class, name = SorterType.SCRIPT),
+
+})
+@Data
+@NoArgsConstructor
+public abstract class JElasticSorter implements Comparable<JElasticSorter>{
+
+    @Min(1)
+    public int priority;
+
+    private SortOrder sortOrder;
+
+    private String sorterType;
+
+    @Override
+    public int compareTo(JElasticSorter o) {
+        return ComparisonChain.start()
+                .compare(priority, o.getPriority())
+                .result();
+    }
+
+    public JElasticSorter(String sorterType) {
+      this.sorterType = sorterType;
+    }
+
+    public JElasticSorter(int priority, SortOrder sortOrder, String sorterType){
+        this.priority = priority;
+        this.sortOrder = sortOrder;
+        this.sorterType = sorterType;
+    }
+
+    public abstract <V> V accept(SorterVisitor<V> visitor);
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
@@ -8,12 +8,12 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Min;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sorterType")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,  property = "sorterType")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = FieldSorter.class, name = SorterType.FIELD),
         @JsonSubTypes.Type(value = GeoDistanceSorter.class, name = SorterType.GEO_DISTANCE),
         @JsonSubTypes.Type(value = ScriptSorter.class, name = SorterType.SCRIPT),
-        @JsonSubTypes.Type(value = ScoreSorter.class, name = SorterType.SCORE),
+        @JsonSubTypes.Type(value = ScoreSorter.class, name = SorterType.SCORE)
 
 })
 @Data

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/JElasticSorter.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.Min;
         @JsonSubTypes.Type(value = FieldSorter.class, name = SorterType.FIELD),
         @JsonSubTypes.Type(value = GeoDistanceSorter.class, name = SorterType.GEO_DISTANCE),
         @JsonSubTypes.Type(value = ScriptSorter.class, name = SorterType.SCRIPT),
+        @JsonSubTypes.Type(value = ScoreSorter.class, name = SorterType.SCORE),
 
 })
 @Data

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/ScoreSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/ScoreSorter.java
@@ -1,0 +1,24 @@
+package io.github.jelastic.core.models.query.sorter;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ScoreSorter extends JElasticSorter {
+
+    public ScoreSorter(){super(SorterType.SCORE);}
+
+    @Builder
+    public ScoreSorter(int priority, SortOrder sortOrder) {
+      super(priority, sortOrder, SorterType.SCORE);
+    }
+
+    @Override
+    public <V> V accept(SorterVisitor<V> visitor) {
+      return visitor.visit(this);
+    }
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/ScriptSorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/ScriptSorter.java
@@ -1,0 +1,37 @@
+package io.github.jelastic.core.models.query.sorter;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.elasticsearch.script.Script;
+
+import javax.validation.constraints.NotNull;
+
+import static org.elasticsearch.search.sort.ScriptSortBuilder.ScriptSortType;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ScriptSorter extends JElasticSorter {
+
+    @NotNull
+    private Script script;
+
+    @NotNull
+    private ScriptSortType scriptSortType;
+
+    public ScriptSorter(){super(SorterType.SCRIPT);}
+
+    @Builder
+    public ScriptSorter(int priority, SortOrder sortOrder, Script script, ScriptSortType scriptSortType) {
+        super(priority, sortOrder, SorterType.SCRIPT);
+        this.script = script;
+        this.scriptSortType = scriptSortType;
+    }
+
+    @Override
+    public <V> V accept(SorterVisitor<V> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.Min;
 
 /**
  * Created by koushikr
- * @deprecated as of 7.2.0-4, replaced by {@link JElasticSorter}
+ * @deprecated as of 7.2.0-5, replaced by {@link JElasticSorter}
  */
 @Data
 @Builder

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Min;
 
 /**
  * Created by koushikr
+ * @deprecated as of 7.2.0-4, replaced by {@link JElasticSorter}
  */
 @Data
 @Builder

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/Sorter.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.Min;
  */
 @Data
 @Builder
+@Deprecated
 public class Sorter implements Comparable<Sorter> {
 
     @Min(1)

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/SorterType.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/SorterType.java
@@ -1,0 +1,11 @@
+package io.github.jelastic.core.models.query.sorter;
+
+public interface SorterType {
+
+    String FIELD = "FIELD";
+
+    String GEO_DISTANCE = "GEO_DISTANCE";
+
+    String SCRIPT = "SCRIPT";
+
+}

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/SorterType.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/SorterType.java
@@ -8,4 +8,6 @@ public interface SorterType {
 
     String SCRIPT = "SCRIPT";
 
+    String SCORE = "SCORE";
+
 }

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/SorterVisitor.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/SorterVisitor.java
@@ -8,4 +8,6 @@ public interface SorterVisitor<T> {
 
     T visit(ScriptSorter scriptSorter);
 
+    T visit(ScoreSorter scoreSorter);
+
 }

--- a/src/main/java/io/github/jelastic/core/models/query/sorter/SorterVisitor.java
+++ b/src/main/java/io/github/jelastic/core/models/query/sorter/SorterVisitor.java
@@ -1,0 +1,11 @@
+package io.github.jelastic.core.models.query.sorter;
+
+public interface SorterVisitor<T> {
+
+    T visit(FieldSorter fieldSorter);
+
+    T visit(GeoDistanceSorter geoDistanceSorter);
+
+    T visit(ScriptSorter scriptSorter);
+
+}

--- a/src/main/java/io/github/jelastic/core/models/search/JElasticSearchRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/search/JElasticSearchRequest.java
@@ -1,0 +1,24 @@
+package io.github.jelastic.core.models.search;
+
+import io.github.jelastic.core.models.query.JElasticQuery;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class JElasticSearchRequest<T> {
+    @NotNull
+    private String index;
+    @NotNull
+    private String type;
+    @NotNull
+    private JElasticQuery query;
+    private Class<T> klass;
+    private Set<String> routingKeys;
+}
+

--- a/src/main/java/io/github/jelastic/core/models/search/JElasticSearchResponse.java
+++ b/src/main/java/io/github/jelastic/core/models/search/JElasticSearchResponse.java
@@ -1,0 +1,15 @@
+package io.github.jelastic.core.models.search;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class JElasticSearchResponse<T> {
+
+  private long count;
+
+  private List<T> entities;
+}

--- a/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.NotNull;
 
 /**
  * @author koushik
+ * @deprecated  as of 7.2.0-4, replaced by {@link JElasticSearchRequest}
  */
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/search/SearchRequest.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 @Builder
+@Deprecated
 public class SearchRequest<T> {
     @NotNull
     private String index;

--- a/src/main/java/io/github/jelastic/core/models/source/DeleteEntityRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/DeleteEntityRequest.java
@@ -1,0 +1,19 @@
+package io.github.jelastic.core.models.source;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class DeleteEntityRequest {
+    @NotNull
+    private String indexName;
+    private String mappingType;
+    @NotNull
+    private String referenceId;
+    private String routingKey;
+}

--- a/src/main/java/io/github/jelastic/core/models/source/EntitySaveRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/EntitySaveRequest.java
@@ -35,5 +35,6 @@ public class EntitySaveRequest {
     private String referenceId;
     @NotNull
     private String value;
+    private String routingKey;
 
 }

--- a/src/main/java/io/github/jelastic/core/models/source/GetSourceRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/GetSourceRequest.java
@@ -34,5 +34,6 @@ public class GetSourceRequest<T> {
     private String indexName;
     private String mappingType;
     private Class<T> klass;
+    private String routingKey;
 
 }

--- a/src/main/java/io/github/jelastic/core/models/source/UpdateEntityRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/UpdateEntityRequest.java
@@ -37,4 +37,6 @@ public class UpdateEntityRequest {
 
     @NotNull
     private String value;
+    private String routingKey;
+
 }

--- a/src/main/java/io/github/jelastic/core/models/source/UpdateFieldRequest.java
+++ b/src/main/java/io/github/jelastic/core/models/source/UpdateFieldRequest.java
@@ -39,4 +39,6 @@ public class UpdateFieldRequest {
     @NotNull
     private Map<String, Object> fieldValueMap;
     private int retryCount;
+    private String routingKey;
+
 }

--- a/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
+++ b/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
@@ -210,7 +210,7 @@ public class ElasticRepository implements Closeable {
                         entitySaveRequest.getReferenceId()
                 )
                 .setSource(entitySaveRequest.getValue(), XContentType.JSON);
-        if (entitySaveRequest.getRoutingKey() !=null)  indexRequestBuilder.setRouting(entitySaveRequest.getRoutingKey());
+        indexRequestBuilder.setRouting(entitySaveRequest.getRoutingKey());
 
         indexRequestBuilder.setRefreshPolicy(
                 WriteRequest.RefreshPolicy.IMMEDIATE
@@ -227,7 +227,7 @@ public class ElasticRepository implements Closeable {
                         updateEntityRequest.getReferenceId()
                 )
                 .setDoc(updateEntityRequest.getValue(), XContentType.JSON);
-        if (updateEntityRequest.getRoutingKey() !=null)  updateRequestBuilder.setRouting(updateEntityRequest.getRoutingKey());
+        updateRequestBuilder.setRouting(updateEntityRequest.getRoutingKey());
         updateRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).execute().actionGet();
     }
 
@@ -330,13 +330,13 @@ public class ElasticRepository implements Closeable {
         SearchRequestBuilder searchRequestBuilder = elasticClient.getClient()
                 .prepareSearch(searchRequest.getIndex())
                 .setQuery(queryBuilder);
-        if (!searchRequest.getRoutingKeys().isEmpty() && !Objects.isNull(searchRequest.getRoutingKeys())) {
+        if (!Objects.isNull(searchRequest.getRoutingKeys()) && !searchRequest.getRoutingKeys().isEmpty()) {
             searchRequestBuilder.setRouting(
                     searchRequest.getRoutingKeys()
                             .toArray(new String[(searchRequest.getRoutingKeys().size())])
             );
         }
-        if (!query.getSorters().isEmpty() && !Objects.isNull(query.getSorters())) {
+        if (!Objects.isNull(query.getSorters()) && !query.getSorters().isEmpty()) {
             queryManager.getSortBuilders(query).forEach(searchRequestBuilder::addSort);
         }
 

--- a/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
+++ b/src/main/java/io/github/jelastic/core/repository/ElasticRepository.java
@@ -271,6 +271,7 @@ public class ElasticRepository implements Closeable {
      * @throws io.github.jelastic.core.exception.InvalidQueryException when query is not built correctly.
      * @return List<T> list of objects that meet searchCriteria
      */
+    @Deprecated
     public <T> List<T> search(SearchRequest<T> searchRequest) {
         validate(searchRequest);
         val query = searchRequest.getQuery();

--- a/src/main/java/io/github/jelastic/core/utils/ElasticUtils.java
+++ b/src/main/java/io/github/jelastic/core/utils/ElasticUtils.java
@@ -15,6 +15,7 @@
  */
 package io.github.jelastic.core.utils;
 
+import io.github.jelastic.core.models.search.JElasticSearchResponse;
 import io.github.jelastic.core.models.source.GetSourceRequest;
 import io.github.jelastic.core.models.template.CreateTemplateRequest;
 import lombok.val;
@@ -46,6 +47,17 @@ public interface ElasticUtils {
                     final Map<String, Object> result = hit.getSourceAsMap();
                     return MapperUtils.mapper().convertValue(result, klass);
                 }).collect(Collectors.toList());
+    }
+
+    static <T> JElasticSearchResponse<T> getSearchResponse(SearchResponse response, Class<T> klass) {
+        return JElasticSearchResponse.<T>builder()
+                .count(response.getHits().getTotalHits().value)
+                .entities(Arrays.stream(response.getHits().getHits())
+                        .map(hit -> {
+                            final Map<String, Object> result = hit.getSourceAsMap();
+                            return MapperUtils.mapper().convertValue(result, klass);
+                        }).collect(Collectors.toList()))
+                .build();
     }
 
     static <T> List<T> getResponse(MultiGetResponse multiGetItemResponses, Class<T> klass) {

--- a/src/main/java/io/github/jelastic/core/utils/ElasticUtils.java
+++ b/src/main/java/io/github/jelastic/core/utils/ElasticUtils.java
@@ -84,6 +84,10 @@ public interface ElasticUtils {
         if (!Objects.isNull(createTemplateRequest.getAnalysis())) {
             settings.put(ElasticProperties.ANALYSIS, createTemplateRequest.getAnalysis());
         }
+        if (!Objects.isNull(createTemplateRequest.getIndexProperties().getNoOfRoutingShards())) {
+            settings.put(ElasticProperties.NO_OF_ROUTING_SHARDS,
+                    createTemplateRequest.getIndexProperties().getNoOfRoutingShards());
+        }
         return settings;
     }
 
@@ -92,5 +96,6 @@ public interface ElasticUtils {
         String NO_OF_REPLICAS = "number_of_replicas";
         String INDEX_REQUEST_CACHE = "index.requests.cache.enable";
         String ANALYSIS = "analysis";
+        String NO_OF_ROUTING_SHARDS = "number_of_routing_shards";
     }
 }


### PR DESCRIPTION
- Added support for polymorphic sorter(JElasticSorter)
    - Added FieldSorter, GeoDistanceSorter, ScriptSorter, ScoreSorter.
    - Deprecated old Sorter.
    - Query has been deprecated and is replaced by JElasticQuery which supports JElasticSorter as its sorter.
- SearchRequest has been deprecated and is replaced by JElasticSearchRequest which supports JElasticQuery as its query.
- Added support for constant score query and match query via ConstantScoreFilter and MatchFilter respectively.
- Added JElasticSearchResponse for returning total count in the search response along with List<T>.
    - Deprecated search operation and replaced it with enumeratedSearch which returns total count along with List<T>.
- Added support for deleting a document.
- Added support for shard routing in update, updateField, enumeratedSearch and delete operations.
- Added support for setting number of routing shards.
